### PR TITLE
Fix incomplete rusty-hook -> rusty-hooks rename

### DIFF
--- a/src/hooks/files/cli.sh
+++ b/src/hooks/files/cli.sh
@@ -16,7 +16,7 @@ noConfigFileExitCode={{NO_CONFIG_FILE_EXIT_CODE}}
 upgradeRustyHooksCli() {
   echo "[rusty-hooks] Upgrading rusty-hook cli..."
   echo "[rusty-hooks] This may take a few seconds..."
-  cargo install --force rusty-hook >/dev/null 2>&1
+  cargo install --force rusty-hooks >/dev/null 2>&1
 }
 
 installRustyHooksCli() {
@@ -51,7 +51,7 @@ handleRustyHooksCliResult() {
       echo "[rusty-hooks] See https://github.com/kaimast/rusty-hooks#configure for more information about configuring rusty-hooks"
       echo
       echo "[rusty-hooks] If you were trying to remove rusty-hooks, then you should also delete the git hook files to remove this warning"
-      echo "[rusty-hooks] See https://github.com/kaimast/rusty-hooks#removing-rusty-hooks for more information about removing rusty-hook from your project"
+      echo "[rusty-hooks] See https://github.com/kaimast/rusty-hooks#removing-rusty-hooks for more information about removing rusty-hooks from your project"
       echo
     fi
     exit 0

--- a/src/hooks/files/hook_script.sh
+++ b/src/hooks/files/hook_script.sh
@@ -10,9 +10,9 @@ gitParams="$*"
 
 if ! command -v rusty-hooks >/dev/null 2>&1; then
   if [ -z "${RUSTY_HOOKS_SKIP_AUTO_INSTALL}" ]; then
-    installRustyHookCli
+    installRustyHooksCli
   else
-    echo "[rusty-hooks] rusty-hook is not installed, and auto install is disabled"
+    echo "[rusty-hooks] rusty-hooks is not installed, and auto install is disabled"
     echo "[rusty-hooks] skipping ${hookName} hook"
     echo "[rusty-hooks] You can reinstall it using 'cargo install rusty-hooks' or delete this hook"
     exit 0


### PR DESCRIPTION
## Changes
Seems like the rename from rusty-hook to rusty-hooks was incomplete, so the part of the hook script that auto-installs rusty-hooks doesn't work properly because it references a nonexistent function. This PR fixes that.
